### PR TITLE
Use scratch as base image to reduce images size even further

### DIFF
--- a/Dockerfile.dist
+++ b/Dockerfile.dist
@@ -1,4 +1,4 @@
-FROM busybox
+FROM scratch
 
 ADD ./dist/vol-cleanup /
 ENTRYPOINT ["/vol-cleanup"]


### PR DESCRIPTION
Due to the fact we're just using a statically linked GO binary, we could skip the usage of a busybox base image and use a plain scratch base image. This results in a really light weight image of 9 MByte only.

```
docker images
REPOSITORY                  TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
cloudnautique/vol-cleanup   latest              45fe567ed8b1        8 minutes ago       9.014 MB
```
